### PR TITLE
Fix helper-templates-in-copyright issue detected by lintian

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ on Fri, 28 Aug 2009 14:51:51 -0400.
 
 It was downloaded from <http://ics-web.sns.ornl.gov/adl2edl/log/show.php>
 
-Upstream Author(s):
+Upstream Authors:
     Joan Sage (TJNAF) <sage@jlab.org>
 
 Copyright:


### PR DESCRIPTION
Fixes this error detected by lintian:

```
E: adl2edl: helper-templates-in-copyright
```
