### PR TITLE
quote strings that could contain whitespaces

### DIFF
--- a/control.cc
+++ b/control.cc
@@ -490,7 +490,7 @@ int shellclass::parse(ifstream &inf, ostream &outf, ostream &outd)
     outf << "commandLabel {" << endl;
     for (int i=0; i<shell_ctr; i++)
         if(shelllist[i].label.length() > 0)
-            outf << "  " << i << " " << shelllist[i].label << endl;
+            outf << "  " << i << " \"" << shelllist[i].label << "\"" << endl;
     outf << "}" << endl;
 
     outf << "command {" << endl;
@@ -870,14 +870,14 @@ int relatedclass::parse(ifstream &inf, ostream &outf, ostream &outd)
 
 	outf << "displayFileName {" << endl;
 	for (int i=0; i<rel_ctr; i++) {
-		outf << "  " << i << " " << rellist[i].name << endl;  
+		outf << "  " << i << " \"" << rellist[i].name << "\"" << endl;  
 		//outd << "Rel Disp: " << rellist[i].name << endl;  
 	}
 	outf << "}" << endl;				
 
 	outf << "menuLabel {" << endl;
 	for (int i=0; i<rel_ctr; i++) 
-		outf << "  " << i << " " << rellist[i].label << endl;  
+		outf << "  " << i << " \"" << rellist[i].label << "\"" << endl;  
 	outf << "}" << endl;				
 
 	// Write 'symbol open curly brace' only if there are args


### PR DESCRIPTION
In the converted EDL files of areaDetector, many related display widgets have spaces in their labels, [for example](https://github.com/areaDetector/ADCore/blob/master/ADApp/op/edl/autoconvert/ADPlugins.edl#L181)

This actually may not disturb EDM, but I would argue it is more of correct syntax. Also it wouldn't disturb my own EDL parser ;-).